### PR TITLE
feat: migrate custom params to valid strapi params._q

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ module.exports = {
 - The plugin provides a global middleware that intercepts requests with `?populate=all` and rewrites the query to trigger recursive population.
 - In the background, it builds a standard Strapi populate query as described in the [Strapi documentation](https://docs.strapi.io/cms/api/rest/populate-select).
 - You can control which relations are included using the relations config option.
-- Inside the document API, you can set `populate: '*'` and `populateAll: true` to make it work
+- Inside the document API, you can set `populate: '*'` and `_q: "populate-all"` to make it work ("populate-all" can be anywhere inside `_q`, we detect it via .includes)

--- a/sandbox/tests/populate-all.test.ts
+++ b/sandbox/tests/populate-all.test.ts
@@ -21,4 +21,44 @@ describe("strapi-plugin-populate-all", () => {
       "category"
     );
   });
+
+  test("if everything is populated with populateAll=true", async () => {
+    const response = await strapiRequest.get(
+      "/api/articles?status=draft&populateAll=true"
+    );
+
+    // request succeeds
+    expect(response.statusCode).toBe(200);
+
+    // has first level of population
+    expect(response.body.data[0]).toHaveProperty("cover");
+    expect(response.body.data[0]).toHaveProperty("author");
+    expect(response.body.data[0]).toHaveProperty("category");
+    expect(response.body.data[0]).toHaveProperty("blocks");
+
+    // doesn't loop
+    expect(response.body.data[0].category.articles[0]).not.toHaveProperty(
+      "category"
+    );
+  });
+
+  test("if everything is populated with ?populateAll", async () => {
+    const response = await strapiRequest.get(
+      "/api/articles?status=draft&populateAll"
+    );
+
+    // request succeeds
+    expect(response.statusCode).toBe(200);
+
+    // has first level of population
+    expect(response.body.data[0]).toHaveProperty("cover");
+    expect(response.body.data[0]).toHaveProperty("author");
+    expect(response.body.data[0]).toHaveProperty("category");
+    expect(response.body.data[0]).toHaveProperty("blocks");
+
+    // doesn't loop
+    expect(response.body.data[0].category.articles[0]).not.toHaveProperty(
+      "category"
+    );
+  });
 });

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -1,5 +1,6 @@
 import type { Core, UID } from "@strapi/strapi";
-import { getPopulateQuery } from "./utils/getPopulateQuery";
+import { PLUGIN_QUERY_DOCUMENT_TAG } from "./config";
+import { getPopulateQuery, queryCache } from "./utils/getPopulateQuery";
 
 const bootstrap = ({ strapi }: { strapi: Core.Strapi }) => {
   strapi.db.lifecycles.subscribe((event) => {
@@ -8,7 +9,11 @@ const bootstrap = ({ strapi }: { strapi: Core.Strapi }) => {
         event.action === "beforeFindMany" ||
         event.action === "beforeFindOne"
       ) {
-        if (strapi.requestContext.get()?.query?.populateAll) {
+        // There is a whitelist of keys we can use to detect our
+        // filter from the params
+        // https://github.com/strapi/strapi/blob/develop/packages/core/utils/src/content-api-constants.ts
+        // We cheat.
+        if (event.params._q?.includes(PLUGIN_QUERY_DOCUMENT_TAG)) {
           strapi.log.debug(
             `[populate-all] recursively populate ${event.model.uid}`
           );
@@ -16,6 +21,14 @@ const bootstrap = ({ strapi }: { strapi: Core.Strapi }) => {
           const populateQuery = getPopulateQuery(event.model.uid as UID.Schema);
           if (populateQuery?.populate) {
             event.params.populate = populateQuery.populate;
+          }
+
+          // Clean our tag from the custom query.
+          const query = event.params._q.replace(PLUGIN_QUERY_DOCUMENT_TAG, "");
+          if (query.length > 0) {
+            event.params._q = query;
+          } else {
+            delete event.params._q;
           }
         }
       }

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -1,6 +1,6 @@
 import type { Core, UID } from "@strapi/strapi";
 import { PLUGIN_QUERY_DOCUMENT_TAG } from "./config";
-import { getPopulateQuery, queryCache } from "./utils/getPopulateQuery";
+import { getPopulateQuery } from "./utils/getPopulateQuery";
 
 const bootstrap = ({ strapi }: { strapi: Core.Strapi }) => {
   strapi.db.lifecycles.subscribe((event) => {

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -1,3 +1,5 @@
+export const PLUGIN_QUERY_DOCUMENT_TAG = "populate-all";
+
 export default {
   default: {
     relations: true,

--- a/server/src/middlewares/index.ts
+++ b/server/src/middlewares/index.ts
@@ -9,6 +9,15 @@ export default {
    * The bootstrap script later picks up `?populateAll=true` to apply the desired populate logic.
    */
   populateAll: async (ctx: Context, next: Next) => {
+    // always bind the tag so we can load the execpected populate hook
+    // populateAll=true or ?populateAll (value can be 'true' or null)
+    if (
+      (ctx.query.populateAll && ctx.query.populateAll !== "false") ||
+      ctx.query.populateAll === null
+    ) {
+      ctx.query._q = [ctx.query._q || "", PLUGIN_QUERY_DOCUMENT_TAG].join("");
+    }
+
     if (ctx.query.populate === "all") {
       ctx.query.populate = undefined;
       ctx.query._q = [ctx.query._q || "", PLUGIN_QUERY_DOCUMENT_TAG].join("");

--- a/server/src/middlewares/index.ts
+++ b/server/src/middlewares/index.ts
@@ -1,4 +1,5 @@
 import type { Context, Next } from "koa";
+import { PLUGIN_QUERY_DOCUMENT_TAG } from "../config";
 
 export default {
   /**
@@ -10,7 +11,7 @@ export default {
   populateAll: async (ctx: Context, next: Next) => {
     if (ctx.query.populate === "all") {
       ctx.query.populate = undefined;
-      ctx.query.populateAll = true;
+      ctx.query._q = [ctx.query._q || "", PLUGIN_QUERY_DOCUMENT_TAG].join("");
     }
     await next();
   },


### PR DESCRIPTION
As the params inside strapi are hardcoded https://github.com/strapi/strapi/blob/develop/packages/core/utils/src/content-api-constants.ts and the validator doesn't take custom config https://github.com/strapi/strapi/blob/develop/packages/core/core/src/services/document-service/params.ts we cannot use our `populateAll` variant anymore 😢 

demo
```
DS {
  processedParams: {
    populate: '*',
    populateAll: true,
    locale: 'en',
    status: 'published',
    filters: { documentId: [Object], l10n: [Object] }
  }
}
DST {
  allowlisted: {
    filters: { documentId: [Object], l10n: [Object] },
    fields: undefined,
    populate: '*',
    status: 'published',
    locale: 'en'
  }
}
```
_processedParams_ is the input value for https://github.com/strapi/strapi/blob/develop/packages/core/core/src/services/document-service/repository.ts#L327

And _allowlisted_ is the version after 🧹 https://github.com/strapi/strapi/blob/develop/packages/core/core/src/services/document-service/transform/query.ts#L9

