### PR TITLE
fix: avoid race conditions on cache and recursion

### DIFF
--- a/server/src/utils/getPopulateQuery.ts
+++ b/server/src/utils/getPopulateQuery.ts
@@ -25,9 +25,10 @@ export const getPopulateQuery = (
         `[populate-all] loop detected skipping population: ${modelUid}`
       );
       return { populate: {} };
-    } else {
-      parentsModelUids.push(modelUid);
     }
+
+    // copy parents uids to avoid mutating the original array during recursion
+    const nextParentsModelUids = [...parentsModelUids, modelUid];
 
     // build query
     const query = { populate: {} };
@@ -47,7 +48,7 @@ export const getPopulateQuery = (
         const components = Object.fromEntries(
           attribute.components.map((component) => [
             component,
-            getPopulateQuery(component, parentsModelUids),
+            getPopulateQuery(component, nextParentsModelUids),
           ])
         );
         query.populate[fieldName] = { on: components };
@@ -58,7 +59,7 @@ export const getPopulateQuery = (
       if (attribute.type === "component") {
         query.populate[fieldName] = getPopulateQuery(
           attribute.component,
-          parentsModelUids
+          nextParentsModelUids
         );
         continue;
       }
@@ -79,7 +80,7 @@ export const getPopulateQuery = (
           query.populate[fieldName] = getPopulateQuery(
             // @ts-expect-error target actually exists on attribute
             attribute.target,
-            parentsModelUids
+            nextParentsModelUids
           );
           continue;
         }
@@ -88,7 +89,7 @@ export const getPopulateQuery = (
           query.populate[fieldName] = getPopulateQuery(
             // @ts-expect-error target actually exists on attribute
             attribute.target,
-            parentsModelUids
+            nextParentsModelUids
           );
           continue;
         }

--- a/server/src/utils/getPopulateQuery.ts
+++ b/server/src/utils/getPopulateQuery.ts
@@ -1,8 +1,20 @@
 import type { UID } from "@strapi/strapi";
 
-// memory cache to only execute query generation ones per modelUid
+// memory cache to only execute query generation once per requested model path
 // biome-ignore lint/suspicious/noExplicitAny: any object can be cached
-export const queryCache: Partial<Record<UID.Schema, any>> = {};
+export const queryCache: Record<string, any> = {};
+
+// generate a unique cache key from the model uid and its parent model uids
+// returns "parent1|parent2|...|modelUid" or just "modelUid" if no parents
+const buildCacheKey = (
+  modelUid: UID.Schema,
+  parentsModelUids: UID.Schema[]
+): string => {
+  if (parentsModelUids.length === 0) {
+    return modelUid;
+  }
+  return `${parentsModelUids.join("|")}|${modelUid}`;
+};
 
 export const getPopulateQuery = (
   modelUid: UID.Schema,
@@ -13,10 +25,12 @@ export const getPopulateQuery = (
     const useCache =
       strapi.plugin("populate-all").config<boolean>("cache") ?? true;
 
+    const cacheKey = buildCacheKey(modelUid, parentsModelUids);
+
     // return cached query
-    if (useCache && queryCache[modelUid]) {
-      strapi.log.debug(`[populate-all] query cache hit: ${modelUid}`);
-      return structuredClone(queryCache[modelUid]); // return a clone to avoid mutating the original object
+    if (useCache && queryCache[cacheKey]) {
+      strapi.log.debug(`[populate-all] query cache hit: ${cacheKey}`);
+      return structuredClone(queryCache[cacheKey]); // return a clone to avoid mutating the original object
     }
 
     // prevent infinite loop
@@ -108,8 +122,8 @@ export const getPopulateQuery = (
 
     // cache query
     if (useCache) {
-      strapi.log.debug(`[populate-all] new query cached: ${modelUid}`);
-      queryCache[modelUid] = query;
+      strapi.log.debug(`[populate-all] new query cached: ${cacheKey}`);
+      queryCache[cacheKey] = query;
     }
     return structuredClone(query); // return a clone to avoid mutating the original object
   } catch (error) {

--- a/server/src/utils/tests/getPopulateQuery.cache.test.ts
+++ b/server/src/utils/tests/getPopulateQuery.cache.test.ts
@@ -62,14 +62,9 @@ describe("getPopulateQuery: cache", () => {
     expect(queryCache).toEqual({});
   });
 
-  test("does not reuse a deep-recursion result into a later top-level query for the same model", () => {
-    // Schema:
-    //   outer → component `inner` → component `self` → relation `sibling` → relation back to `inner`
-    // When `outer` is walked first, the recursion reaches `inner` a second time
-    // as an ancestor, so `self` is legitimately short-circuited to { populate: {} }.
-    // If that result is cached under the bare key `inner`, a subsequent top-level
-    // walk of `inner` (e.g. `/api/inner?populate=all`) returns the shallow cached
-    // version even though `inner` is NOT an ancestor in the top-level call.
+  test("caches nested and top-level queries for the same model independently", () => {
+    // outer → inner → inner-body → back to inner (loop-detected, short-circuited)
+    // A top-level query on `inner` must not reuse the short-circuited nested result.
     mockStrapi.plugin.mockReturnValue({
       config: vi
         .fn()
@@ -105,14 +100,11 @@ describe("getPopulateQuery: cache", () => {
       }
     });
 
-    // deep `inner` is reached twice, second time as an ancestor,
-    // producing a legitimately shallow sub-tree for the inner occurrence
+    // walk outer first — caches a short-circuited version of `inner`
     getPopulateQuery("outer" as UID.Schema);
 
-    // top-level on `inner`, ust NOT reuse the deep result
+    // top-level query on `inner` must produce a full populate tree
     const topLevelInner = getPopulateQuery("inner" as UID.Schema);
-
-    // `self` and `sibling` must be populated since they are NOT ancestors here
     expect(topLevelInner).toEqual({
       populate: {
         self: {
@@ -142,7 +134,6 @@ describe("getPopulateQuery: cache", () => {
     });
 
     const result = getPopulateQuery("model" as UID.Schema);
-    // @ts-expect-error: simulating race condition where `queryCache` gets overwritten by other call
     queryCache.model.populate.media = false;
 
     expect(result).toEqual({

--- a/server/src/utils/tests/getPopulateQuery.cache.test.ts
+++ b/server/src/utils/tests/getPopulateQuery.cache.test.ts
@@ -62,6 +62,73 @@ describe("getPopulateQuery: cache", () => {
     expect(queryCache).toEqual({});
   });
 
+  test("does not reuse a deep-recursion result into a later top-level query for the same model", () => {
+    // Schema:
+    //   outer → component `inner` → component `self` → relation `sibling` → relation back to `inner`
+    // When `outer` is walked first, the recursion reaches `inner` a second time
+    // as an ancestor, so `self` is legitimately short-circuited to { populate: {} }.
+    // If that result is cached under the bare key `inner`, a subsequent top-level
+    // walk of `inner` (e.g. `/api/inner?populate=all`) returns the shallow cached
+    // version even though `inner` is NOT an ancestor in the top-level call.
+    mockStrapi.plugin.mockReturnValue({
+      config: vi
+        .fn()
+        .mockImplementation((key) =>
+          key === "relations" ? true : key === "cache" ? true : undefined
+        ),
+    });
+    mockStrapi.getModel.mockImplementation((uid) => {
+      switch (uid) {
+        case "outer":
+          return {
+            attributes: { child: { type: "component", component: "inner" } },
+          };
+        case "inner":
+          return {
+            attributes: {
+              self: { type: "component", component: "inner-body" },
+              sibling: { type: "relation", target: "sibling" },
+            },
+          };
+        case "inner-body":
+          return {
+            attributes: {
+              back: { type: "relation", target: "inner" },
+            },
+          };
+        case "sibling":
+          return {
+            attributes: { back: { type: "relation", target: "inner" } },
+          };
+        default:
+          return { attributes: {} };
+      }
+    });
+
+    // deep `inner` is reached twice, second time as an ancestor,
+    // producing a legitimately shallow sub-tree for the inner occurrence
+    getPopulateQuery("outer" as UID.Schema);
+
+    // top-level on `inner`, ust NOT reuse the deep result
+    const topLevelInner = getPopulateQuery("inner" as UID.Schema);
+
+    // `self` and `sibling` must be populated since they are NOT ancestors here
+    expect(topLevelInner).toEqual({
+      populate: {
+        self: {
+          populate: {
+            back: { populate: expect.anything() },
+          },
+        },
+        sibling: {
+          populate: {
+            back: { populate: expect.anything() },
+          },
+        },
+      },
+    });
+  });
+
   test("cache does not mutate original object", () => {
     mockStrapi.plugin.mockReturnValue({
       config: vi

--- a/server/src/utils/tests/getPopulateQuery.test.ts
+++ b/server/src/utils/tests/getPopulateQuery.test.ts
@@ -94,14 +94,10 @@ describe("getPopulateQuery", () => {
     });
   });
 
-  test("does not falsely loop-detect across sibling subtrees", () => {
-    // Schema:
-    //   root has two component siblings A and B.
-    //   A's subtree references shared component C.
-    //   B's subtree also references shared component C.
-    // With the previous mutation-based parents stack, walking A would leave
-    // ['root', 'A', 'C'] on the stack; the subsequent walk into B would then
-    // see 'C' as an "ancestor" and short-circuit B.c to { populate: {} }.
+  test("populates a shared component used by siblings", () => {
+    // root → A → C and root → B → C
+    // C appears in both sibling subtrees but is never an ancestor,
+    // so it must be fully populated in both branches.
     mockStrapi.plugin.mockReturnValue({
       config: vi
         .fn()
@@ -139,7 +135,7 @@ describe("getPopulateQuery", () => {
 
     const result = getPopulateQuery("root" as UID.Schema);
 
-    // B.c must be populated the same way as A.c, not collapsed to {}.
+    // both branches must fully populate C
     expect(result).toEqual({
       populate: {
         a: { populate: { c: { populate: true } } },
@@ -148,7 +144,7 @@ describe("getPopulateQuery", () => {
     });
   });
 
-  test("does not mutate the parents array passed by the caller", () => {
+  test("preserves the caller's parents array", () => {
     mockStrapi.getModel.mockReturnValue({
       attributes: { foo: { type: "string" } },
     });

--- a/server/src/utils/tests/getPopulateQuery.test.ts
+++ b/server/src/utils/tests/getPopulateQuery.test.ts
@@ -94,6 +94,71 @@ describe("getPopulateQuery", () => {
     });
   });
 
+  test("does not falsely loop-detect across sibling subtrees", () => {
+    // Schema:
+    //   root has two component siblings A and B.
+    //   A's subtree references shared component C.
+    //   B's subtree also references shared component C.
+    // With the previous mutation-based parents stack, walking A would leave
+    // ['root', 'A', 'C'] on the stack; the subsequent walk into B would then
+    // see 'C' as an "ancestor" and short-circuit B.c to { populate: {} }.
+    mockStrapi.plugin.mockReturnValue({
+      config: vi
+        .fn()
+        .mockImplementation((key) => (key === "relations" ? true : undefined)),
+    });
+    mockStrapi.getModel.mockImplementation((uid) => {
+      switch (uid) {
+        case "root":
+          return {
+            attributes: {
+              a: { type: "component", component: "A" },
+              b: { type: "component", component: "B" },
+            },
+          };
+        case "A":
+          return {
+            attributes: {
+              c: { type: "component", component: "C" },
+            },
+          };
+        case "B":
+          return {
+            attributes: {
+              c: { type: "component", component: "C" },
+            },
+          };
+        case "C":
+          return {
+            attributes: { leaf: { type: "string" } },
+          };
+        default:
+          return { attributes: {} };
+      }
+    });
+
+    const result = getPopulateQuery("root" as UID.Schema);
+
+    // B.c must be populated the same way as A.c, not collapsed to {}.
+    expect(result).toEqual({
+      populate: {
+        a: { populate: { c: { populate: true } } },
+        b: { populate: { c: { populate: true } } },
+      },
+    });
+  });
+
+  test("does not mutate the parents array passed by the caller", () => {
+    mockStrapi.getModel.mockReturnValue({
+      attributes: { foo: { type: "string" } },
+    });
+
+    const parents: UID.Schema[] = ["outer" as UID.Schema];
+    getPopulateQuery("inner" as UID.Schema, parents);
+
+    expect(parents).toEqual(["outer"]);
+  });
+
   test("returns undefined on error", () => {
     mockStrapi.getModel.mockImplementation(() => {
       throw new Error("fail");


### PR DESCRIPTION
This PR fixes a couple of issues that I've noticed on my Strapi instance, when using `populate=all` on more complex models, and in particular when reusing components. 

It was particularly tricky to figure out since it would only happen when calling endpoints in a specific order, which would corrupt the cache. I've also included some tests to check for the specific behaviors that were triggering the bugs in my case. 

**Changes**:

- properly copy the recursion tree array, to avoid sharing unrelated data
- use a more complex cache key for deeper models

**Related**:

- this might also be a fix for https://github.com/faessler/strapi-plugin-populate-all/issues/16, even though I haven't tested that specific scenario