### PR TITLE
fix(#27): ensure pagination reflects population

### DIFF
--- a/sandbox/tests/populate-all.test.ts
+++ b/sandbox/tests/populate-all.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, test } from "@jest/globals";
 import { strapiRequest } from "./strapi";
 
 describe("strapi-plugin-populate-all", () => {
+  test("if pagination reflects populated data", async () => {
+    const response = await strapiRequest.get(
+      "/api/articles?status=draft&populate=all"
+    );
+
+    expect(response.body.meta.pagination.total).toBe(response.body.data.length);
+    expect(response.body.meta.pagination.pageCount).toBeGreaterThanOrEqual(1);
+  });
+
   test("if everything is populated", async () => {
     const response = await strapiRequest.get(
       "/api/articles?status=draft&populate=all"

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -7,7 +7,8 @@ const bootstrap = ({ strapi }: { strapi: Core.Strapi }) => {
     try {
       if (
         event.action === "beforeFindMany" ||
-        event.action === "beforeFindOne"
+        event.action === "beforeFindOne" ||
+        event.action === "beforeCount"
       ) {
         // There is a whitelist of keys we can use to detect our
         // filter from the params


### PR DESCRIPTION
When fetching collection with `populate=all` everything got populated as expected BUT pagination count was "0". This is due to some strapi core change. Adding `beforeCount` in the bootstrap db lifecycle injector fixes this issue.